### PR TITLE
FIX: Usunięto order by z definicji widoku PerfMon

### DIFF
--- a/SQL Server Performance.sql
+++ b/SQL Server Performance.sql
@@ -4,8 +4,7 @@ GO
 CREATE VIEW PerfMon AS
 SELECT CONVERT(DATETIME, CAST(CounterDateTime AS VARCHAR(19))) AS CounterDateTime,
 MachineName, ObjectName, CounterName, InstanceName, CounterValue
-FROM dbo.CounterData AS D JOIN dbo.CounterDetails AS C ON D.CounterID = C.CounterID 
-ORDER BY CounterDateTime;
+FROM dbo.CounterData AS D JOIN dbo.CounterDetails AS C ON D.CounterID = C.CounterID ;
 GO
 
 SELECT *


### PR DESCRIPTION
Nie ma tej lini w artykule .
Przy próbie wykonania: 
Msg 1033, Level 15, State 1, Procedure PerfMon1, Line 5
The ORDER BY clause is invalid in views, inline functions, derived tables, subqueries, and common table expressions, unless TOP or FOR XML is also specified.